### PR TITLE
Explicitly state minimum node version supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "author": "Matt Hayward <matt@matthayward.com.au>",
   "license": "MIT",
-  "engines" : { 
+  "devEngines" : { 
     "node" : ">=6.16.0" 
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "Matt Hayward <matt@matthayward.com.au>",
   "license": "MIT",
+  "engines" : { 
+    "node" : ">=6.16.0" 
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",


### PR DESCRIPTION
I'm not sure of the lowest version of node this project supports

May be able to tweak this in the babelrc too 
